### PR TITLE
Fixed display of alphanumeric chars in hex panel (+numbered header)

### DIFF
--- a/application/src/main/kotlin/org/mp4parser/isoviewer/views/MainView.kt
+++ b/application/src/main/kotlin/org/mp4parser/isoviewer/views/MainView.kt
@@ -230,7 +230,7 @@ class MainView : View("ISO Viewer") {
                             isSortable = false
                             prefWidth = 400.0
                         }
-                        column("................", String::class) {
+                        column("0123456789ABCDEF", String::class) {
                             isSortable = false
                             prefWidth = 150.0
                             value { param ->
@@ -238,8 +238,8 @@ class MainView : View("ISO Viewer") {
                                 val itra = param.value.iterator()
                                 while (itra.hasNext()) {
                                     val b = itra.nextByte()
-                                    s += if (Character.isLetterOrDigit(b.toInt())) {
-                                        Character.forDigit(b.toInt(), 10)
+                                    s += if (Character.isLetterOrDigit(b.toInt()) || b.toInt() == 0x20) {
+                                        b.toInt().toChar()
                                     } else {
                                         '.'
                                     }


### PR DESCRIPTION
For an unknown reason; Character.toDigit() did not work, switching to a simple toChar() does the trick
(also support blanks, and improve column header for ascii representation)